### PR TITLE
Add methods for creating TOTP/HOTP from raw bytes and from base32-encoded strings

### DIFF
--- a/src/hotp.rs
+++ b/src/hotp.rs
@@ -32,11 +32,13 @@ impl HOTP {
         HOTP { secret: secret.into().into_bytes() }
     }
 
+    /// Constructs a new `HOTP` with base-32 encoded secret bytes
     pub fn from_base32<S: Into<String>>(secret: S) -> Option<HOTP> {
         base32::decode(RFC4648 { padding: false }, &secret.into())
             .map(|secret| HOTP { secret })
     }
 
+    /// Constructs a new `HOTP` with secret bytes
     pub fn from_bytes(bytes: &[u8]) -> HOTP {
         HOTP { secret: bytes.into() }
     }
@@ -86,6 +88,7 @@ impl HOTP {
         false
     }
 
+    /// Return the secret bytes in base32 encoding.
     pub fn base32_secret(&self) -> String {
         base32::encode(RFC4648 { padding: false }, &self.secret)
     }

--- a/src/totp.rs
+++ b/src/totp.rs
@@ -30,11 +30,13 @@ impl TOTP {
         TOTP { hotp: HOTP::new(secret) }
     }
 
+    /// Constructs a new `TOTP` with base-32 encoded secret bytes
     pub fn from_base32<S: Into<String>>(secret: S) -> Option<TOTP> {
         HOTP::from_base32(secret)
             .map(|hotp| TOTP { hotp })
     }
 
+    /// Constructs a new `TOTP` with secret bytes
     pub fn from_bytes(bytes: &[u8]) -> TOTP {
         TOTP { hotp: HOTP::from_bytes(bytes) }
     }
@@ -74,6 +76,11 @@ impl TOTP {
             rv |= a ^ b;
         }
         rv == 0
+    }
+
+    /// Return the secret bytes in base32 encoding.
+    pub fn base32_secret(&self) -> String {
+        self.hotp.base32_secret()
     }
 
     /// Generate the otpauth protocal string.

--- a/src/totp.rs
+++ b/src/totp.rs
@@ -15,8 +15,6 @@
 //! }
 //! ```
 
-use base32::Alphabet::RFC4648;
-
 use super::hotp::HOTP;
 
 
@@ -30,6 +28,11 @@ impl TOTP {
     /// Constructs a new `TOTP`
     pub fn new<S: Into<String>>(secret: S) -> TOTP {
         TOTP { hotp: HOTP::new(secret) }
+    }
+
+    pub fn from_base32<S: Into<String>>(secret: S) -> Option<TOTP> {
+        HOTP::from_base32(secret)
+            .map(|hotp| TOTP { hotp })
     }
 
     pub fn from_bytes(bytes: &[u8]) -> TOTP {
@@ -79,10 +82,9 @@ impl TOTP {
     ///
     /// ``issuer``: The company, the organization or something else.
     pub fn to_uri<S: AsRef<str>>(&self, label: S, issuer: S) -> String {
-        let encoded_secret = base32::encode(RFC4648 { padding: false }, &self.hotp.secret);
         format!("otpauth://totp/{}?secret={}&issuer={}",
                 label.as_ref(),
-                encoded_secret,
+                self.hotp.base32_secret(),
                 issuer.as_ref())
     }
 }


### PR DESCRIPTION
Currently the crate only accepts secrets in the form of `String`s, which are valid UTF-8 by definition. The UTF-8 bytes of the string are then taken directly as the OTP secret. This is an unnecessary restriction on the possible secrets and significantly reduces the entropy in the resulting secret.

I added new methods for creating `TOTP` and `HOTP` from raw bytes and from base32-encoded strings.

Given the security shortcomings of the existing approach, I would also suggest that a release including these changes deprecate or remove the current `new` method and include a strong recommendation in the documentation/README to move to the `from_bytes`/`from_base32` methods.

I used `Option<T>` as the return type for the `from_base32` methods in order to keep these changes self-contained, but it might be worth adding an error type and using `Result` instead.